### PR TITLE
golangci-lint | Disable default exclusions in cfg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,15 @@
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.
 
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/todo#29
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
 linters:
   enable:
     - depguard


### PR DESCRIPTION
- fixes GH-26
- refs atc0005/todo#29