### PR TITLE
Add "canary" Dockerfile, Dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,22 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "ghaw"
+
+  # Monitor Go updates to serve as a reminder to generate fresh binaries
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/go"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "canary"

--- a/.github/workflows/lint-docker-files.yml
+++ b/.github/workflows/lint-docker-files.yml
@@ -1,0 +1,31 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/nagios-debug
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Linting
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  linting:
+    name: Lint Dockerfile files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: index.docker.io/hadolint/hadolint:latest-debian
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+
+      - name: Run hadolint against all Dockerfile files
+        run: |
+          hadolint dependabot/docker/go/Dockerfile

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/nagios-debug
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# Purpose:
+#
+# "Canary" Dockerfile for Go updates, monitored by Dependabot.
+#
+# After Dependabot provides a (valid) Pull Request to update this file, I
+# should begin the process of preparing a new project release (including
+# binaries) to reflect that version of Go.
+
+# https://hub.docker.com/_/golang
+FROM golang:1.16.5


### PR DESCRIPTION
- Add Dockerfile representing Go release used for project
- Add Dependabot job to monitor Dockerfile
- Add GitHub Actions Workflow to lint Dockerfile

fixes GH-62