### PR TITLE
Update Go version recommendation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.17"
-          - "< 1.16"
+          - ">= 1.18"
+          - "< 1.17"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Small Nagios plugin to return "debug" environment details
 - [Overview](#overview)
 - [Features](#features)
 - [Changelog](#changelog)
+- [Requirements](#requirements)
   - [Building source code](#building-source-code)
   - [Running](#running)
 - [Installation](#installation)
@@ -53,9 +54,20 @@ but not yet an official release may also be noted in the file under the
 `Unreleased` section. A helpful link to the Git commit history since the last
 official release is also provided for further review.
 
+## Requirements
+
+The following is a loose guideline. Other combinations of Go and operating
+systems for building and running tools from this repo may work, but have not
+been tested.
+
 ### Building source code
 
-- Go 1.13+
+- Go
+  - see this project's `go.mod` file for *preferred* version
+  - this project tests against [officially supported Go
+    releases][go-supported-releases]
+    - the most recent stable release (aka, "stable")
+    - the prior, but still supported release (aka, "oldstable")
 - GCC
   - if building with custom options (as the provided `Makefile` does)
 - `make`
@@ -63,11 +75,8 @@ official release is also provided for further review.
 
 ### Running
 
-- Windows 7, Server 2008R2 or later
-  - per official [Go install notes][go-docs-install]
-- Windows 10 Version 1909
-  - tested
-- Ubuntu Linux 16.04, 18.04
+- Windows 10
+- Ubuntu Linux 18.04+
 
 ## Installation
 
@@ -187,5 +196,7 @@ SOFTWARE.
 [go-docs-download]: <https://golang.org/dl>  "Download Go"
 
 [go-docs-install]: <https://golang.org/doc/install>  "Install Go"
+
+[go-supported-releases]: <https://go.dev/doc/devel/release#policy> "Go Release Policy"
 
 <!-- []: PLACEHOLDER "DESCRIPTION_HERE" -->

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -14,4 +14,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.16.12
+FROM golang:1.17.5

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/atc0005/nagios-debug
 
-go 1.15
+go 1.17
 
 require github.com/atc0005/go-nagios v0.8.2

--- a/vendor/github.com/atc0005/go-nagios/go.mod
+++ b/vendor/github.com/atc0005/go-nagios/go.mod
@@ -1,3 +1,0 @@
-module github.com/atc0005/go-nagios
-
-go 1.14

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,3 @@
 # github.com/atc0005/go-nagios v0.8.2
-## explicit
+## explicit; go 1.14
 github.com/atc0005/go-nagios


### PR DESCRIPTION
- Update README
  - to direct reader to this project's go.mod file for the preferred
    Go version
  - to use reflinks vs hard-coded values
  - link to official supported Go versions documentation
- Update `go.mod` file to reflect Go 1.17
- Update Dependabot (`dependabot.yml`) configuration to ignore Go
  versions greater than or less than 1.17.x
- Update "canary" Dockerfile to reflect Go 1.17.5, the prior version
  in the 1.17.x series
  - opting to use "one version back" in order to confirm that
    Dependabot picks up the changes as intended
- Run `go mod tidy && go mod vendor`
  - updates format of go.mod to list project dependencies in separate
    direct and transitive require blocks
  - prunes go.mod, go.sum files from vendored dependencies
  - updates format of vendor/modules.txt to note specific version of
    Go used by vendored dependencies

fixes GH-100