### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/check_debug/doc.go
+++ b/cmd/check_debug/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/nagios-debug
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Nagios plugin used to "echo" back detected environment variables and
+// provided CLI flags/values as part of service check output to help
+// troubleshoot other "real" service checks.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/nagios-debug
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive package-comment linting error
surfaced by recent linter update.