### PR TITLE
Fix Makefile Go module base path detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ WHAT 					= check_debug
 # work as intended.
 #
 # What package holds the "version" variable used in branding/version output?
-# VERSION_VAR_PKG			= $(shell go list .)
-# VERSION_VAR_PKG			= $(shell go list .)/internal/config
+# VERSION_VAR_PKG			= $(shell go list -m)
+# VERSION_VAR_PKG			= $(shell go list -m)/internal/config
 VERSION_VAR_PKG			= main
 
 OUTPUTDIR 				= release_assets


### PR DESCRIPTION
Replace `go list .` with `go list -m` to reflect that most projects now no longer contain a doc.go file in the project root.

NOTE: This set of changes does not directly impact the plugin provided by this project as it does not emit version output, but rather updates the VERSION_VAR_PKG var in case this plugin is updated in the future to include this info.

refs https://github.com/atc0005/todo/issues/46